### PR TITLE
Enable unstable feature(convert)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@
 
 #![doc(html_root_url = "http://alexcrichton.com/gcc-rs")]
 #![cfg_attr(test, deny(warnings))]
+#![feature(convert)]
 
 use std::env;
 use std::fs;


### PR DESCRIPTION
Fixes unstable errors such as:

    Compiling gcc v0.3.4
    /root/.cargo/registry/src/github.com-1ecc6299db9ec823/gcc-0.3.4/src/lib.rs:115:23: 115:34 error: use of unstable library feature 'convert': recently added, experimental traits
    /root/.cargo/registry/src/github.com-1ecc6299db9ec823/gcc-0.3.4/src/lib.rs:115     pub fn include<P: AsRef<Path>>(&mut self, dir: P) -> &mut Config {