### PR TITLE
RFC: Quasi-incremental builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ C compiler to compile native C code into a static archive to be linked into Rust
 code.
 """
 keywords = ["build-dependencies"]
+
+[dependencies]
+filetime = "0.1"

--- a/pants.c
+++ b/pants.c
@@ -1,0 +1,5 @@
+#include "pants.h"
+
+extern void pants(const char *name)
+{
+}

--- a/pants.h
+++ b/pants.h
@@ -1,0 +1,1 @@
+#include <stdint.h>

--- a/shirt.c
+++ b/shirt.c
@@ -1,0 +1,6 @@
+#include "pants.h"
+#include "shirt.h"
+
+extern void shirt(const char *name)
+{
+}

--- a/shirt.h
+++ b/shirt.h
@@ -1,0 +1,1 @@
+#include <stdio.h>

--- a/tests/pants.rs
+++ b/tests/pants.rs
@@ -1,0 +1,9 @@
+extern crate gcc;
+
+#[test]
+fn test() {
+	gcc::Config::new()
+		.file("pants.c")
+		.file("shirt.c")
+		.compile("libpants.a");
+}


### PR DESCRIPTION
**Objective:** Avoid lengthy, unnecessary compiler runs on every build by doing basic dependency checking.

Next steps:

- [x] Capture header dependencies from a preprocessor run, e.g. `cc -M -MG` (which works with `gcc` and `clang`).
- [x] Build a cache of dependencies and their modification times, to avoid duplicate work after each preprocessor run.
- [x] Add support for Windows systems, noting that the `MetadataExt`-provided modification time properties will be different. (Aha, [filetime](https://crates.io/crates/filetime)!)
- [ ] Support Rust 1.0 (which lacks `MetadataExt`), if @alexcrichton regards that as important. (Doesn't look like the `filetime` helps.)
- [ ] Add header dependency support for `msvc`.

Notes:

* Basic [performance testing](https://gist.github.com/jdub/9382c3e9ebcbb839d6f6) suggests that doing a single preprocessor run is not a significant win. This means we can skip the preprocessor run (and dependency modification checks) entirely if the input file itself is changed.
* Investigate preprocessor output of `msvc`. The `/showIncludes` parameter looks promising (though probably not as neat as the Makefile output).