### PR TITLE
Add the option to disable linking against the main crate

### DIFF
--- a/gcc-test/build.rs
+++ b/gcc-test/build.rs
@@ -72,5 +72,5 @@ fn main() {
 
     // This tests whether we  can build a library but not link it to the main crate.
     // The test module will do its own linking.
-    gcc::Config::new().link(false).file("src/opt_linkage.c").compile("libOptLinkage.a");
+    gcc::Config::new().cargo_metadata(false).file("src/opt_linkage.c").compile("libOptLinkage.a");
 }

--- a/gcc-test/build.rs
+++ b/gcc-test/build.rs
@@ -69,4 +69,8 @@ fn main() {
         println!("cargo:rustc-link-lib=msvc");
         println!("cargo:rustc-link-search={}", out.display());
     }
+
+    // This tests whether we  can build a library but not link it to the main crate.
+    // The test module will do its own linking.
+    gcc::Config::new().link(false).file("src/opt_linkage.c").compile("libOptLinkage.a");
 }

--- a/gcc-test/src/opt_linkage.c
+++ b/gcc-test/src/opt_linkage.c
@@ -1,0 +1,5 @@
+#include<stdint.h>
+
+int32_t answer() {
+ return 42;
+}

--- a/gcc-test/tests/all.rs
+++ b/gcc-test/tests/all.rs
@@ -2,6 +2,14 @@ extern crate gcc_test;
 
 use gcc_test::*;
 
+
+// This will cause a link failure if the archive is already
+// linked against the gcc_test crate.
+#[link(name = "OptLinkage", kind = "static")]
+extern {
+  fn answer() -> i32;
+}
+
 #[test]
 fn foo_here() {
     unsafe {
@@ -45,4 +53,9 @@ fn msvc_here() {
     unsafe {
         msvc();
     }
+}
+
+#[test]
+fn opt_linkage() {
+   unsafe { assert_eq!(answer(),42); }
 }


### PR DESCRIPTION
Hi,

I have a suggestion for an improvement: At the moment, the archives produced by a build script using gcc-rs are unconditionally linked to the crate that is being built. But there are certain use cases where that is not desirable, for example when you only want to [link the built artifact for tests](https://users.rust-lang.org/t/cargo-how-to-build-external-static-lib-only-when-testing/1241). This is presently only possible by dropping down to constructing the compiler command line manually, which is not really desirable for portability reasons.
So I propose adding a `link()` option that you can add to the configuration in order to disable linking. The default would still be `true`, of course. Please have a look and tell me what you think. 

Thanks,

Niels