### PR TITLE
If hard-linking fails, try to copy (in assemble())

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -468,10 +468,10 @@ impl Config {
             // exist for now.
             let lib_dst = dst.with_file_name(format!("{}.lib", lib_name));
             let _ = fs::remove_file(&lib_dst);
-            if fs::hard_link(&dst, &lib_dst).is_err() {
-                println!("Hard-linking from {:?} to {:?} failed. Trying to copy...", dst, lib_dst);
-                fs::copy(&dst, &lib_dst).expect("Copying from {:?} to {:?} FAILED.");
-            };
+            fs::hard_link(&dst, &lib_dst).or_else(|_| {
+                //if hard-link fails, just copy (ignoring the number of bytes written)
+                fs::copy(&dst, &lib_dst).map(|_| ())
+            }).expect("Copying from {:?} to {:?} failed.");;
         } else {
             let ar = self.get_ar();
             let cmd = ar.file_name().unwrap().to_string_lossy();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -471,7 +471,7 @@ impl Config {
             fs::hard_link(&dst, &lib_dst).or_else(|_| {
                 //if hard-link fails, just copy (ignoring the number of bytes written)
                 fs::copy(&dst, &lib_dst).map(|_| ())
-            }).expect("Copying from {:?} to {:?} failed.");;
+            }).ok().expect("Copying from {:?} to {:?} failed.");;
         } else {
             let ar = self.get_ar();
             let cmd = ar.file_name().unwrap().to_string_lossy();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -468,7 +468,10 @@ impl Config {
             // exist for now.
             let lib_dst = dst.with_file_name(format!("{}.lib", lib_name));
             let _ = fs::remove_file(&lib_dst);
-            fs::hard_link(dst, lib_dst).unwrap();
+            if fs::hard_link(&dst, &lib_dst).is_err() {
+                println!("Hard-linking from {:?} to {:?} failed. Trying to copy...", dst, lib_dst);
+                fs::copy(&dst, &lib_dst).expect("Copying from {:?} to {:?} FAILED.");
+            };
         } else {
             let ar = self.get_ar();
             let cmd = ar.file_name().unwrap().to_string_lossy();


### PR DESCRIPTION
Fix for the failure described [here](https://users.rust-lang.org/t/openssl-sys-on-rust-32-bit-msvc-does-it-work/2893/2). I have my code checked out in a Virtual Machine on a Shared Drive (so I can e.g. use git outside the VM). Hard_linking doesn't work there.