### PR TITLE
skip empty include directory

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,11 @@ impl Config {
 
     /// Add a directory to the `-I` or include path for headers
     pub fn include<P: AsRef<Path>>(&mut self, dir: P) -> &mut Config {
+        if let Some(path_str) = dir.as_ref().to_str() {
+            if path_str.trim().is_empty() {
+                return self
+            }
+        }
         self.include_directories.push(dir.as_ref().to_path_buf());
         self
     }


### PR DESCRIPTION
I encounter a error building openssl on CentOS 6. Which cause by empty -I option value. Empty include directories can be checked in gcc-rs clients, but I think it would be better to prevent this kind of error upstream on gcc-rs.
```
   Compiling openssl-sys-extras v0.7.0
Build failed, waiting for other jobs to finish...
failed to run custom build command for `openssl-sys-extras v0.7.0`
Process didn't exit successfully: `/home/jarod/workspace/rust/myapp/target/release/build/openssl-sys-extras-825d1c761df64e08/build-script-build` (exit code: 101)
--- stdout
TARGET = Some("x86_64-unknown-linux-gnu")
OPT_LEVEL = Some("3")
PROFILE = Some("release")
TARGET = Some("x86_64-unknown-linux-gnu")
debug=false opt-level=3
HOST = Some("x86_64-unknown-linux-gnu")
TARGET = Some("x86_64-unknown-linux-gnu")
TARGET = Some("x86_64-unknown-linux-gnu")
HOST = Some("x86_64-unknown-linux-gnu")
CC_x86_64-unknown-linux-gnu = None
CC_x86_64_unknown_linux_gnu = None
HOST_CC = None
CC = None
HOST = Some("x86_64-unknown-linux-gnu")
TARGET = Some("x86_64-unknown-linux-gnu")
HOST = Some("x86_64-unknown-linux-gnu")
CFLAGS_x86_64-unknown-linux-gnu = None
CFLAGS_x86_64_unknown_linux_gnu = None
HOST_CFLAGS = None
CFLAGS = None
running: "cc" "-O3" "-ffunction-sections" "-fdata-sections" "-m64" "-fPIC" "-I" "" "-o" "/home/jarod/workspace/rust/myapp/target/release/build/openssl-sys-extras-825d1c761df64e08/out/src/openssl_shim.o" "-c" "src/openssl_shim.c"
ExitStatus(Code(1))


command did not execute successfully, got: exit code: 1



--- stderr
cc1: error: src/openssl_shim.c: not a directory
thread '<main>' panicked at 'explicit panic', /home/jarod/.multirust/toolchains/stable/cargo/registry/src/github.com-0a35038f75765ae4/gcc-0.3.19/src/lib.rs:771
```