### PR TITLE
Add armv7-unknown-linux-gnueabihf to the list of supported targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -596,7 +596,8 @@ impl Config {
                 let prefix = match &target[..] {
                     "aarch64-unknown-linux-gnu" => Some("aarch64-linux-gnu"),
                     "arm-unknown-linux-gnueabi" => Some("arm-linux-gnueabi"),
-                    "arm-unknown-linux-gnueabihf" => Some("arm-linux-gnueabihf"),
+                    "arm-unknown-linux-gnueabihf"  => Some("arm-linux-gnueabihf"),
+                    "armv7-unknown-linux-gnueabihf" => Some("arm-linux-gnueabihf"),
                     "powerpc-unknown-linux-gnu" => Some("powerpc-linux-gnu"),
                     "powerpc64-unknown-linux-gnu" => Some("powerpc-linux-gnu"),
                     "powerpc64le-unknown-linux-gnu" => Some("powerpc64le-linux-gnu"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -432,6 +432,10 @@ impl Config {
             if target.contains("musl") {
                 cmd.args.push("-static".into());
             }
+
+            if target == "armv7-unknown-linux-gnueabihf" {
+                cmd.args.push("-march=armv7-a".into());
+            }
         }
 
         if self.cpp && !msvc {


### PR DESCRIPTION
That let us select the appropriate default compiler.