### PR TITLE
Bump to 0.3.27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "gcc"
-version = "0.3.26"
+version = "0.3.27"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/alexcrichton/gcc-rs"


### PR DESCRIPTION
Do you mind merging this and then publishing this version to crates.io? I'm planning to start sending out pull requests to the main Rust repo for the ARM MUSL support, and I'll need to bump the Cargo dependencies to this new version to pull in 49e9f30dc70b590bd5ac89f75f78d2f41c13ace5.