### PR TITLE
Add weight to the gcc parallel tasks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,7 +367,7 @@ impl Config {
         }
         drop(rayon::initialize(cfg));
 
-        objs.par_iter().for_each(|&(ref src, ref dst)| {
+        objs.par_iter().weight_max().for_each(|&(ref src, ref dst)| {
             self.compile_object(src, dst)
         })
     }


### PR DESCRIPTION
Tasks are not parallelized until their total "cost" exceeds 10k.
The weight of a vector is the length of the vector. The weight of
the task is increased by 5% for each additional task added (eg
for_each), but for compilation phases, because the step itself is
quite expensive, it is worth increasing the weight to force maximum
parallelism. This fixes the issue I mentioned in #90 