### PR TITLE
Move output directory creation out of parallel code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "gcc"
-version = "0.3.33"
+version = "0.3.34"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/alexcrichton/gcc-rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,6 +337,7 @@ impl Config {
             } else {
                 obj
             };
+            fs::create_dir_all(&obj.parent().unwrap()).unwrap();
             src_dst.push((file.to_path_buf(), obj.clone()));
             objects.push(obj);
         }
@@ -393,7 +394,6 @@ impl Config {
             (cmd, compiler.path.file_name().unwrap()
                           .to_string_lossy().into_owned())
         };
-        fs::create_dir_all(&dst.parent().unwrap()).unwrap();
         if msvc && is_asm {
             cmd.arg("/Fo").arg(dst);
         } else if msvc {


### PR DESCRIPTION
The create_dir_all function is not threadsafe. It
non-atomically checks if a directory exists and then
creates it. This change moves the creation to serial
code prior to the compilation loop.

Fixes #94 