### PR TITLE
Add default cpp_link_stdlib for FreeBSD target

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -802,6 +802,8 @@ impl Config {
                 None
             } else if target.contains("darwin") {
                 Some("c++".to_string())
+            } else if target.contains("freebsd") {
+                Some("c++".to_string())
             } else {
                 Some("stdc++".to_string())
             }


### PR DESCRIPTION
FreeBSD defaults to Clang, libc++ would be a preferred lib.