### PR TITLE
use armv6s-m instead of armv6-m

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -519,6 +519,10 @@ impl Config {
             }
             if target.starts_with("thumbv7em") {
                 cmd.args.push("-march=armv7e-m".into());
+
+                if target.ends_with("eabihf") {
+                    cmd.args.push("-mfpu=fpv4-sp-d16".into())
+                }
             }
             if target.starts_with("thumbv7m") {
                 cmd.args.push("-march=armv7-m".into());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -515,7 +515,7 @@ impl Config {
                 }
             }
             if target.starts_with("thumbv6m") {
-                cmd.args.push("-march=armv6-m".into());
+                cmd.args.push("-march=armv6s-m".into());
             }
             if target.starts_with("thumbv7em") {
                 cmd.args.push("-march=armv7e-m".into());


### PR DESCRIPTION
This allows use of the SVC instruction and matches what rustc gets from LLVM with thumbv6m.

From the GCC manual
> -march=armv6s-m is the ‘armv6-m’ architecture with support for the (now mandatory) SVC instruction.

I have also added a commit to specify the minimum FPU for the `thumbv7em` hard float target.