### PR TITLE
Add ATL/MFC detection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,7 +365,6 @@ impl Config {
             });
 
             if let Some(atlmfc_lib) = atlmfc_lib {
-                self.print("cargo:rustc-link-lib=static=atls");
                 self.print(&format!("cargo:rustc-link-search=native={}",
                                     atlmfc_lib.display()));
             }

--- a/src/windows_registry.rs
+++ b/src/windows_registry.rs
@@ -211,6 +211,11 @@ pub fn find_tool(target: &str, tool: &str) -> Option<Tool> {
             let sub = otry!(vc_lib_subdir(target));
             tool.libs.push(path.join("lib").join(sub));
             tool.include.push(path.join("include"));
+            let atlmfc_path = path.join("atlmfc");
+            if atlmfc_path.exists() {
+                tool.libs.push(atlmfc_path.join("lib").join(sub));
+                tool.include.push(atlmfc_path.join("include"));
+            }
             Some(tool)
         }).next()
     }


### PR DESCRIPTION
Fixes #115. Unfortunately, the linker workaround for `rustc` is quite messy.