### PR TITLE
Update README; `cargo build -jN` will set/override $NUM_JOBS for you

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,9 @@ gcc = { version = "0.3", features = ["parallel"] }
 ```
 
 By default gcc-rs will limit parallelism to `$NUM_JOBS`, or if not present it
-will limit it to the number of cpus on the machine.
+will limit it to the number of cpus on the machine. If you are using cargo,
+use `-jN` option of `build`, `test` and `run` commands as `$NUM_JOBS`
+is supplied by cargo.
 
 ## Compile-time Requirements
 


### PR DESCRIPTION
This is a doc-only update. It took me some time to figure out why `NUM_JOBS=4 cargo build` does not limit the number of parallelism to 4, but to the number of cpu cores. (The correct way is `cargo build -j4`.)

Thanks!