### PR TITLE
Fix suprious warning for cpp

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -661,6 +661,7 @@ impl Config {
 
         if self.cpp {
             match (self.cpp_set_stdlib.as_ref(), cmd.family) {
+                (None, _) => { }
                 (Some(stdlib), ToolFamily::Gnu) |
                 (Some(stdlib), ToolFamily::Clang) => {
                     cmd.args.push(format!("-stdlib=lib{}", stdlib).into());


### PR DESCRIPTION
Fix spurious warning:
warning: cpp_set_stdlib is specified, but the Gnu compiler does not support this option, ignored

Issue #131 