### PR TITLE
Use softfp float ABI on 32bit ARM Android GCC.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -602,6 +602,7 @@ impl Config {
                 if target.starts_with("armv7-linux-androideabi") {
                     cmd.args.push("-march=armv7-a".into());
                     cmd.args.push("-mfpu=vfpv3-d16".into());
+                    cmd.args.push("-mfloat-abi=softfp".into());
                 }
 
                 // For us arm == armv6 by default


### PR DESCRIPTION
The NDK docs[0] say:

> To target armeabi-v7a with GCC, you must set the following flags when invoking the compiler: -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16.

I added `-mfloat-abi=softfp` because `-march=armv7-a` and `-mfpu=vfpv3-d16` are already set.

[0] https://developer.android.com/ndk/guides/standalone_toolchain.html#abi_compatibility