### PR TITLE
Use armv6t2 instead of armv6

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -607,7 +607,7 @@ impl Config {
 
                 // For us arm == armv6 by default
                 if target.starts_with("arm-unknown-linux-") {
-                    cmd.args.push("-march=armv6".into());
+                    cmd.args.push("-march=armv6t2".into());
                     cmd.args.push("-marm".into());
                 }
 


### PR DESCRIPTION
This is required to correctly build `compiler-rt` of [rust-lang/rust](https://github.com/rust-lang/rust) with LLVM 4.0.

I don't know what exactly the consequences of this change are, however in general `armv6t2` seems to be widely supported. However note that the raspberry pi 1, for example, apparently does not support Thumb 2. See also the [Wikipedia List of ARM Microarchitectures](https://en.wikipedia.org/wiki/List_of_ARM_microarchitectures).

cc @nagisa: You have done some research into this as well, I believe.

cc rust-lang/rust#40123