### PR TITLE
add '-march=armv7-a' to all armv7 linux targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -594,7 +594,7 @@ impl Config {
                 }
 
                 // armv7 targets get to use armv7 instructions
-                if target.starts_with("armv7-unknown-linux-") {
+                if target.starts_with("armv7-") && target.contains("-linux-") {
                     cmd.args.push("-march=armv7-a".into());
                 }
 


### PR DESCRIPTION
This is related to my other changes that add support for chromeos specific target triples.