### PR TITLE
lib.rs: use Display rather than Debug for ExitStatus

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1092,7 +1092,7 @@ fn run(cmd: &mut Command, program: &str) {
     let (mut child, print) = spawn(cmd, program);
     let status = child.wait().expect("failed to wait on child process");
     print.join().unwrap();
-    println!("{:?}", status);
+    println!("{}", status);
     if !status.success() {
         fail(&format!("command did not execute successfully, got: {}", status));
     }
@@ -1105,7 +1105,7 @@ fn run_output(cmd: &mut Command, program: &str) -> Vec<u8> {
     child.stdout.take().unwrap().read_to_end(&mut stdout).unwrap();
     let status = child.wait().expect("failed to wait on child process");
     print.join().unwrap();
-    println!("{:?}", status);
+    println!("{}", status);
     if !status.success() {
         fail(&format!("command did not execute successfully, got: {}", status));
     }


### PR DESCRIPTION
println!("{0}\n{0:?}", status) =>
exit code: 0
ExitStatus(ExitStatus(0))
 
I think the former makes more sense.