### PR TITLE
Fix confusion with uclibc triplets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1045,7 +1045,7 @@ impl Tool {
         let family = if let Some(fname) = path.file_name().and_then(|p| p.to_str()) {
             if fname.contains("clang") {
                 ToolFamily::Clang
-            } else if fname.contains("cl") {
+            } else if fname.contains("cl") && !fname.contains("uclibc") {
                 ToolFamily::Msvc
             } else {
                 ToolFamily::Gnu


### PR DESCRIPTION
Hello! So I'm working on getting Rust to run on `mips-unknown-linux-uclibc`, and it looks like `gcc` gets confused before `mips-openwrt-uclibc-gcc` has `cl` in the name. I hope this is an okay fix