### PR TITLE
RFC: Handle custom targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ appveyor = { repository = "alexcrichton/gcc-rs" }
 
 [dependencies]
 rayon = { version = "0.7", optional = true }
+serde_json = "1.0"
 
 [features]
 parallel = ["rayon"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@
 
 #[cfg(feature = "parallel")]
 extern crate rayon;
+extern crate serde_json;
 
 use std::env;
 use std::ffi::{OsString, OsStr};
@@ -163,6 +164,42 @@ pub fn compile_library(output: &str, files: &[&str]) {
     c.compile(output);
 }
 
+fn get_possibly_custom_target() -> Option<String> {
+    // Try to open this as a file (custom target), if it fails then
+    // assume it's a built in target and just return that
+    env::var("TARGET").ok().map_or(None, |env| {
+        // XXX This is a puzzle for later:
+        let pwd = env::var("PWD").unwrap();
+        println!("here, env is {}", env);
+        println!("and PWD is {}", pwd);
+        println!("yet this will fail: {:?}", fs::File::open(&env));
+        let fullpath = Path::new(&pwd).join(&env);
+        println!("and this will work: {:?}", fs::File::open(&fullpath));
+
+        // Working around the above
+        match fs::File::open(&fullpath) {
+            Ok(file) => {
+                let work_around_carrier_trait: Result<serde_json::Value, serde_json::Error> = serde_json::from_reader(file);
+                match work_around_carrier_trait {
+                    Ok(specs) => {
+                        let llvm_target = specs["llvm-target"].clone();
+                        match llvm_target {
+                            serde_json::Value::String(s) => Some(s),
+                            _ => None,
+                        }
+                    }
+                    Err(_) => None
+                }
+            }
+            Err(e) => {
+                println!("Err: {}", e);
+                None
+            }
+        }
+    })
+}
+
+
 impl Config {
     /// Construct a new instance of a blank set of configuration.
     ///
@@ -177,7 +214,7 @@ impl Config {
             cpp: false,
             cpp_link_stdlib: None,
             cpp_set_stdlib: None,
-            target: None,
+            target: get_possibly_custom_target(),
             host: None,
             out_dir: None,
             opt_level: None,


### PR DESCRIPTION
For [Tock](https://www.tockos.org/), we use custom [target specifications](https://github.com/helena-project/tock/blob/master/boards/hail/sam4l.json) for each supported board. With the merging of https://github.com/rust-lang/rust/pull/35021, when I set up https://github.com/rust-lang-nursery/compiler-builtins for Tock, it invoked `cc` instead of `arm-none-eabi-gcc`. I traced that decision back to this crate, where compiler selection logic depends on matching against a list of known targets.

Unfortunately, our custom target causes the `TARGET` environment variable to be set to something like `sam4l.json`, which is not a known target. However, we can look inside the specs file at the `llvm-target` key to pull out the right target.

The PR is a quick proof-of-concept that always tries to treat the `TARGET` as a specs file, but falls back to treating it as a well-known target string if the file doesn't exist. I think this is a reasonable approach to handle custom targets, but am open to any other ideas you may have.