### PR TITLE
Only add the 'host dylib path' to the MSVC 2017 PATH

### DIFF
--- a/src/windows_registry.rs
+++ b/src/windows_registry.rs
@@ -214,13 +214,12 @@ mod impl_ {
 
     fn tool_from_vs15_instance(tool: &str, target: &str,
                                instance: &SetupInstance) -> Option<Tool> {
-        let (bin_path, host_bin_path, lib_path, include_path) = otry!(vs15_vc_paths(target, instance));
+        let (bin_path, host_dylib_path, lib_path, include_path) = otry!(vs15_vc_paths(target, instance));
         let tool_path = bin_path.join(tool);
         if !tool_path.exists() { return None };
 
         let mut tool = MsvcTool::new(tool_path);
-        tool.path.push(bin_path.clone());
-        tool.path.push(host_bin_path);
+        tool.path.push(host_dylib_path);
         tool.libs.push(lib_path);
         tool.include.push(include_path);
 
@@ -255,10 +254,10 @@ mod impl_ {
         // But! we also need PATH to contain the target directory for the host
         // architecture, because it contains dlls like mspdb140.dll compiled for
         // the host architecture.
-        let host_bin_path = path.join("bin").join(&format!("Host{}", host)).join(&host.to_lowercase());
+        let host_dylib_path = path.join("bin").join(&format!("Host{}", host)).join(&host.to_lowercase());
         let lib_path = path.join("lib").join(&target);
         let include_path = path.join("include");
-        Some((bin_path, host_bin_path, lib_path, include_path))
+        Some((bin_path, host_dylib_path, lib_path, include_path))
     }
 
     fn atl_paths(target: &str, path: &Path) -> Option<(PathBuf, PathBuf)> {


### PR DESCRIPTION
This passed bors and should be the last update to support MSVC 2017.

It is just removing one path from PATH. I think it will not affect any behavior in practice, but this is more correct, so I'd like to get the correct version into all the tools.

Can you publish another build? Sorry again for all the churn.