### PR TITLE
fix arm-linux-androideabi-gcc -Oz error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -602,7 +602,13 @@ impl Config {
             }
             ToolFamily::Gnu |
             ToolFamily::Clang => {
-                cmd.args.push(format!("-O{}", opt_level).into());
+                // arm-linux-androideabi-gcc 4.8 shipped with Android NDK does not support '-Oz'
+                if target.contains("android") && &opt_level[..] == "z" {
+                    cmd.args.push("-Os".into());;
+                } else {
+                    cmd.args.push(format!("-O{}", opt_level).into());
+                }
+
                 if !nvcc {
                     cmd.args.push("-ffunction-sections".into());
                     cmd.args.push("-fdata-sections".into());


### PR DESCRIPTION
arm-linux-androideabi-gcc 4.8 shipped with Android NDK does not support '-Oz'

```
ndk-standalone-18-arm/bin/arm-linux-androideabi-gcc
arm-linux-androideabi-gcc --version
arm-linux-androideabi-gcc (GCC) 4.8
```

fix problems like this:
```
 running: "arm-linux-androideabi-gcc" "-Oz" "-ffunction-sections" "-fdata-sections" "-fPIC" "-o" "/xxx/target/arm-linux-androideabi/release/build/rust-crypto-3870fe536ca5f5ce/out/src/util_helpers.o" "-c" "src/util_helpers.c"
cargo:warning=cc1: error: argument to '-O' should be a non-negative integer, 'g', 's' or 'fast'
ExitStatus(ExitStatus(256))
```