### PR TITLE
Add some panic conditions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -501,6 +501,12 @@ impl Config {
     /// Run the compiler, generating the file `output`
     ///
     /// The name `output` must begin with `lib` and end with `.a`
+    ///
+    /// # Panics
+    ///
+    /// Panics if `output` is not formatted correctly or if one of the underlying 
+    /// compiler commands fails. It can also panic if it fails reading file names
+    /// or creating directories.
     pub fn compile(&self, output: &str) {
         assert!(output.starts_with("lib"));
         assert!(output.ends_with(".a"));
@@ -611,6 +617,10 @@ impl Config {
     /// Run the compiler, returning the macro-expanded version of the input files.
     ///
     /// This is only relevant for C and C++ files.
+    ///
+    /// # Panics
+    ///
+    /// Panics if compiler path has an invalid file name.
     pub fn expand(&self) -> Vec<u8> {
         let compiler = self.get_compiler();
         let mut cmd = compiler.to_command();


### PR DESCRIPTION
Just a try in order to help on https://github.com/alexcrichton/gcc-rs/issues/181. I don't know gcc and I'm not english, so the quality of this PR may be a bit poor!

I found another `unwrap` in a public function (`expand`) so I added a doc for this one too. I'm not sure about the text "compiler path has an invalid file name" though.