### PR TITLE
Add a compile_binary function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "gcc"
-version = "0.3.51"
+version = "0.3.52"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/alexcrichton/gcc-rs"

--- a/gcc-test/build.rs
+++ b/gcc-test/build.rs
@@ -91,4 +91,9 @@ fn main() {
         .expand();
     let out = String::from_utf8(out).unwrap();
     assert!(out.contains("hello world"));
+
+    // Tests that we can build a binary.
+    gcc::Config::new()
+        .file("src/hello.c")
+        .compile_binary("hello");
 }

--- a/gcc-test/src/hello.c
+++ b/gcc-test/src/hello.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main() {
+  printf("Hello World!\n");
+
+  return 0;
+}

--- a/gcc-test/src/hello.c
+++ b/gcc-test/src/hello.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 
 int main() {
-  printf("Hello World!\n");
+  printf("Hello World!");
 
   return 0;
 }

--- a/gcc-test/tests/all.rs
+++ b/gcc-test/tests/all.rs
@@ -19,7 +19,7 @@ fn hello_works() {
     let output = child.wait_with_output().expect("Failed to wait on hello.").stdout;
     let output = String::from_utf8(output).unwrap();
 
-    assert_eq!(output, "Hello World!\n");
+    assert_eq!(output, "Hello World!");
 }
 
 #[test]

--- a/gcc-test/tests/all.rs
+++ b/gcc-test/tests/all.rs
@@ -2,9 +2,24 @@ extern crate gcc_test;
 
 use gcc_test::*;
 
+use std::path::Path;
+use std::process::{Command, Stdio};
+
 #[link(name = "OptLinkage", kind = "static")]
 extern "C" {
     fn answer() -> i32;
+}
+
+#[test]
+fn hello_works() {
+    let child = Command::new(Path::new(env!("OUT_DIR")).join("hello"))
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("Failed to execute hello.");
+    let output = child.wait_with_output().expect("Failed to wait on hello.").stdout;
+    let output = String::from_utf8(output).unwrap();
+
+    assert_eq!(output, "Hello World!\n");
 }
 
 #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -6,6 +6,29 @@ use support::Test;
 mod support;
 
 #[test]
+fn gnu_binary() {
+    let test = Test::gnu();
+    test.gcc()
+        .file("hello.c")
+        .compile_binary("hello");
+
+    test.cmd(0)
+        .must_have("-o")
+        .must_not_have("-c")
+        .must_have(test.td.path().join("hello"));
+}
+
+#[test]
+#[should_panic]
+fn gnu_binary_multifile() {
+    let test = Test::gnu();
+    test.gcc()
+        .file("hello.c")
+        .file("foo.c")
+        .compile_binary("hello");
+}
+
+#[test]
 fn gnu_smoke() {
     let test = Test::gnu();
     test.gcc()
@@ -209,6 +232,28 @@ fn gnu_static() {
     test.cmd(0)
         .must_have("-static")
         .must_not_have("-shared");
+}
+
+#[test]
+fn msvc_binary() {
+    let test = Test::msvc();
+    test.gcc()
+        .file("hello.c")
+        .compile_binary("hello.exe");
+
+    test.cmd(0)
+        .must_not_have("/c")
+        .must_have(&format!("/Fe{}", test.td.path().join("hello.exe").display()));
+}
+
+#[test]
+#[should_panic]
+fn msvc_binary_multifile() {
+    let test = Test::msvc();
+    test.gcc()
+        .file("hello.c")
+        .file("foo.c")
+        .compile_binary("hello");
 }
 
 #[test]


### PR DESCRIPTION
Sometimes, the output of a program which must be written in C/C++ is useful for a build script. This enables building such a program, which can then be called later in the build script with `Stdio::piped()` to retrieve that output. Alternatives include asking the user to manually build the program ahead of time in a README, or calling the C/C++ compiler by hand with `std::process::Command`.

In order to keep the implementation simple, `compile_binary` only supports single-object-file programs, and panics if any more than one than one file is provided. I believe panic-ing to be an acceptable result here since providing multiple files is always a programming mistake and failing silently could produce unexpected behavior and hard-to-find bugs. This decision could be changed later if there is demand.

I've tested this on Linux, but I don't have easy access to a Windows box to test it on. I'm reasonably confident that it should work there, and appveyor will prove it one way or another.