### PR TITLE
Add note that crate can compile assembly.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,10 @@
 //! This crate will automatically detect situations such as cross compilation or
 //! other environment variables set by Cargo and will build code appropriately.
 //!
+//! The crate is not limited to C code, it can accept any source code that can
+//! be passed to a C or C++ compiler. As such, assembly files with extensions
+//! `.s` (gcc/clang) and `.asm` (MSVC) can also be compiled.
+//!
 //! [`Config`]: struct.Config.html
 //!
 //! # Examples


### PR DESCRIPTION
Closes #193. I tried to keep the brief summary style of the rest of the main crate doc. If you would like me to include an example I can do that, I just need a place to put them. The top of the crate docs didn't seem like the right place.