### PR TITLE
Clarify behavior of `expand`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -609,6 +609,17 @@ impl Config {
     /// Run the compiler, returning the macro-expanded version of the input files.
     ///
     /// This is only relevant for C and C++ files.
+    ///
+    /// # Panics
+    /// Panics if more than one file is present in the config, as macro
+    /// expansion only makes sense for a single file.
+    ///
+    /// # Example
+    /// ```no_run
+    /// gcc::Config::new()
+    ///             .file("src/foo.c")
+    ///             .expand()
+    /// ```
     pub fn expand(&self) -> Vec<u8> {
         let compiler = self.get_compiler();
         let mut cmd = compiler.to_command();
@@ -616,6 +627,10 @@ impl Config {
             cmd.env(a, b);
         }
         cmd.arg(compiler.family.expand_flag());
+
+        assert_eq!(self.files.len(), 1,
+                  "Expand may only be called for a single file");
+
         for file in self.files.iter() {
             cmd.arg(file);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -611,14 +611,13 @@ impl Config {
     /// This is only relevant for C and C++ files.
     ///
     /// # Panics
-    /// Panics if more than one file is present in the config, as macro
-    /// expansion only makes sense for a single file.
+    /// Panics if more than one file is present in the config.
     ///
     /// # Example
     /// ```no_run
     /// let out = gcc::Config::new()
-    ///                    .file("src/foo.c")
-    ///                    .expand();
+    ///                       .file("src/foo.c")
+    ///                       .expand();
     /// ```
     pub fn expand(&self) -> Vec<u8> {
         let compiler = self.get_compiler();
@@ -628,8 +627,8 @@ impl Config {
         }
         cmd.arg(compiler.family.expand_flag());
 
-        assert_eq!(self.files.len(), 1,
-                  "Expand may only be called for a single file");
+        assert!(self.files.len() <= 1,
+                "Expand may only be called for a single file");
 
         for file in self.files.iter() {
             cmd.arg(file);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -616,9 +616,9 @@ impl Config {
     ///
     /// # Example
     /// ```no_run
-    /// gcc::Config::new()
-    ///             .file("src/foo.c")
-    ///             .expand()
+    /// let out = gcc::Config::new()
+    ///                    .file("src/foo.c")
+    ///                    .expand();
     /// ```
     pub fn expand(&self) -> Vec<u8> {
         let compiler = self.get_compiler();


### PR DESCRIPTION
Resolves [#187](https://github.com/alexcrichton/gcc-rs/issues/187).

I wasn't too sure what this should do if there's no files in the config. Expanding no files seems like a strange thing to do, but it wasn't clear to me that attempting to do so should also be a panic condition.