### PR TITLE
Added in error checking for the compile() and expand() functions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rust:
 matrix:
   include:
     # Minimum version supported
-    - rust: 1.9.0
+    - rust: 1.13.0
       install:
       script: cargo build
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ pub struct Error {
 
 impl Error {
     fn new(kind: ErrorKind, message: &str) -> Error {
-        Error { kind, message: message.to_owned() }
+        Error { kind: kind, message: message.to_owned() }
     }
 }
 


### PR DESCRIPTION
Initial attempt to resolve issue #192.

New functions try_compile() and try_expand() have been introduced that returns a result. I have introduced the `Error` struct type, which is used within the result in the form of `Result<_, Error>`. The error contains the type of error (`enum ErrorKind`, unused for now) and a detailed message (`String`) to display to the user.

I also had to change the signature of the pubic function get_compiler(), in order to propagate errors (in this specific case, it is because of environment vars missing) - if you don't want to do this, maybe I can put in try_get_compiler and get_compiler?

This was pretty fun to work on, I might have a go at some others. One problem I ran into was you can't propagate a `Result<>` from a closure (used within `Option<>::unwrap_or_else()` calls), so I moved the relevant code out into a match statement instead. Not sure if there was another way to do this, but I at least understand why it's not allowed.

