### PR TITLE
Config: accept Into<Option<&str>> instead of Option<&str>

### DIFF
--- a/gcc-test/build.rs
+++ b/gcc-test/build.rs
@@ -14,7 +14,7 @@ fn main() {
         .flag_if_supported("-Wall")
         .flag_if_supported("-Wfoo-bar-this-flag-does-not-exist")
         .define("FOO", None)
-        .define("BAR", Some("1"))
+        .define("BAR", "1")
         .compile("libfoo.a");
 
     gcc::Config::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,8 +240,8 @@ impl Config {
     ///             .define("BAZ", None)
     ///             .compile("foo");
     /// ```
-    pub fn define(&mut self, var: &str, val: Option<&str>) -> &mut Config {
-        self.definitions.push((var.to_string(), val.map(|s| s.to_string())));
+    pub fn define<'a, V: Into<Option<&'a str>>>(&mut self, var: &str, val: V) -> &mut Config {
+        self.definitions.push((var.to_string(), val.into().map(|s| s.to_string())));
         self
     }
 
@@ -385,8 +385,8 @@ impl Config {
     /// otherwise cargo will link against the specified library.
     ///
     /// The given library name must not contain the `lib` prefix.
-    pub fn cpp_link_stdlib(&mut self, cpp_link_stdlib: Option<&str>) -> &mut Config {
-        self.cpp_link_stdlib = Some(cpp_link_stdlib.map(|s| s.into()));
+    pub fn cpp_link_stdlib<'a, V: Into<Option<&'a str>>>(&mut self, cpp_link_stdlib: V) -> &mut Config {
+        self.cpp_link_stdlib = Some(cpp_link_stdlib.into().map(|s| s.into()));
         self
     }
 
@@ -410,7 +410,8 @@ impl Config {
     /// be used, otherwise `-stdlib` is added to the compile invocation.
     ///
     /// The given library name must not contain the `lib` prefix.
-    pub fn cpp_set_stdlib(&mut self, cpp_set_stdlib: Option<&str>) -> &mut Config {
+    pub fn cpp_set_stdlib<'a, V: Into<Option<&'a str>>>(&mut self, cpp_set_stdlib: V) -> &mut Config {
+        let cpp_set_stdlib = cpp_set_stdlib.into();
         self.cpp_set_stdlib = cpp_set_stdlib.map(|s| s.into());
         self.cpp_link_stdlib(cpp_set_stdlib);
         self

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -152,7 +152,7 @@ fn gnu_include() {
 fn gnu_define() {
     let test = Test::gnu();
     test.gcc()
-        .define("FOO", Some("bar"))
+        .define("FOO", "bar")
         .define("BAR", None)
         .file("foo.c")
         .compile("libfoo.a");
@@ -266,7 +266,7 @@ fn msvc_include() {
 fn msvc_define() {
     let test = Test::msvc();
     test.gcc()
-        .define("FOO", Some("bar"))
+        .define("FOO", "bar")
         .define("BAR", None)
         .file("foo.c")
         .compile("libfoo.a");


### PR DESCRIPTION
Per @dtolnay's suggestion, change methods on Config that accepts Option<&str> to
accept Into<Option<&str>> to make the calls look neater.

Fixes #224 