### PR TITLE
Add useful derives for `VsVers`

### DIFF
--- a/src/windows_registry.rs
+++ b/src/windows_registry.rs
@@ -87,6 +87,7 @@ pub fn find_tool(target: &str, tool: &str) -> Option<Tool> {
 }
 
 /// A version of Visual Studio
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum VsVers {
     /// Visual Studio 12 (2013)
     Vs12,


### PR DESCRIPTION
I needed `Debug`, but I guess the others are useful as well?