### PR TITLE
Fix flag_if_supported for C++ only flags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,7 @@ pub struct Build {
     definitions: Vec<(String, Option<String>)>,
     objects: Vec<PathBuf>,
     flags: Vec<String>,
+    flags_supported: Vec<String>,
     files: Vec<PathBuf>,
     cpp: bool,
     cpp_link_stdlib: Option<Option<String>>,
@@ -254,6 +255,7 @@ impl Build {
             definitions: Vec::new(),
             objects: Vec::new(),
             flags: Vec::new(),
+            flags_supported: Vec::new(),
             files: Vec::new(),
             shared_flag: None,
             static_flag: None,
@@ -373,11 +375,8 @@ impl Build {
     ///            .compile("foo");
     /// ```
     pub fn flag_if_supported(&mut self, flag: &str) -> &mut Build {
-        if self.is_flag_supported(flag).unwrap_or(false) {
-            self.flag(flag)
-        } else {
-            self
-        }
+        self.flags_supported.push(flag.to_string());
+        self
     }
 
     /// Set the `-shared` flag.
@@ -1105,6 +1104,12 @@ impl Build {
 
         for flag in self.flags.iter() {
             cmd.args.push(flag.into());
+        }
+
+        for flag in self.flags_supported.iter() {
+            if self.is_flag_supported(flag).unwrap_or(false) {
+                cmd.args.push(flag.into());
+            }
         }
 
         for &(ref key, ref value) in self.definitions.iter() {

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -36,7 +36,7 @@ impl Test {
 
     pub fn gnu() -> Test {
         let t = Test::new();
-        t.shim("cc").shim("ar");
+        t.shim("cc").shim("c++").shim("ar");
         t
     }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -216,11 +216,29 @@ fn gnu_flag_if_supported() {
         .file("foo.c")
         .flag_if_supported("-Wall")
         .flag_if_supported("-Wflag-does-not-exist")
+        .flag_if_supported("-std=c++11")
         .compile("foo");
 
     test.cmd(0)
         .must_have("-Wall")
-        .must_not_have("-Wflag-does-not-exist");
+        .must_not_have("-Wflag-does-not-exist")
+        .must_not_have("-std=c++11");
+}
+
+#[test]
+fn gnu_flag_if_supported_cpp() {
+    if cfg!(windows) {
+        return
+    }
+    let test = Test::gnu();
+    test.gcc()
+        .cpp(true)
+        .file("foo.cpp")
+        .flag_if_supported("-std=c++11")
+        .compile("foo");
+
+    test.cmd(0)
+        .must_have("-std=c++11");
 }
 
 #[test]


### PR DESCRIPTION
Fixes #236. 

Note that in order to test with `cpp(true)`, I had to add a shim to `c++`. 